### PR TITLE
Biocontainer patch 1

### DIFF
--- a/earlGrey
+++ b/earlGrey
@@ -324,6 +324,26 @@ Checks()
 	else
 		echo "Conda environment is inactive, please activate conda environment before using Earl Grey"; exit 1
 	fi
+
+	# biocontainer checks
+	if [ -d "/usr/local/share/RepeatMasker/Libraries/" ]; then
+		if grep -q Placeholder /usr/local/share/RepeatMasker/Libraries/Dfam.h5 ; then
+			while true; do
+				read -p "Are you using the biocontainer? Please confirm so we can source Dfam and configure for you. [YyNn]" yn
+				case $yn in
+					[Yy]* ) cd /usr/local/share/RepeatMasker/Libraries/
+						curl -O https://dfam.org/releases/Dfam_3.7/families/Dfam_curatedonly.h5.gz
+						gunzip Dfam_curatedonly.h5.gz && mv Dfam.h5 Dfam.h5.bak
+						mv Dfam_curatedonly.h5 Dfam.h5
+						cd /usr/local/share/RepeatMasker/
+						perl configure -rmblast_dir=/usr/local/bin -libdir=/usr/local/share/RepeatMasker/Libraries -trf_prgm=/usr/local/bin/trf -default_search_engine=rmblast
+						break;;
+					[Nn]* ) exit;;
+					* ) echo "Please answer yes or no.";;
+				esac
+			done
+		fi
+	fi
 }
 
 # Main #

--- a/earlGrey
+++ b/earlGrey
@@ -329,7 +329,7 @@ Checks()
 	if [ -d "/usr/local/share/RepeatMasker/Libraries/" ]; then
 		if grep -q Placeholder /usr/local/share/RepeatMasker/Libraries/Dfam.h5 ; then
 			while true; do
-				read -p "Are you using the biocontainer? Please confirm so we can source Dfam and configure for you. [YyNn]" yn
+				read -p "Are you using the biocontainer installation? If yes, we can configure RepeatMasker to work for you:[YyNn]" yn
 				case $yn in
 					[Yy]* ) cd /usr/local/share/RepeatMasker/Libraries/
 						curl -O https://dfam.org/releases/Dfam_3.7/families/Dfam_curatedonly.h5.gz
@@ -337,6 +337,8 @@ Checks()
 						mv Dfam_curatedonly.h5 Dfam.h5
 						cd /usr/local/share/RepeatMasker/
 						perl configure -rmblast_dir=/usr/local/bin -libdir=/usr/local/share/RepeatMasker/Libraries -trf_prgm=/usr/local/bin/trf -default_search_engine=rmblast
+						sed -i 's|${SCRIPT_DIR}/LTR_FINDER_parallel|perl ${SCRIPT_DIR}/LTR_FINDER_parallel|g' /usr/local/share/earlgrey*/scripts/rcMergeRepeatsLoose
+						sed -i 's|${SCRIPT_DIR}/LTR_FINDER_parallel|perl ${SCRIPT_DIR}/LTR_FINDER_parallel|g' /usr/local/share/earlgrey*/scripts/rcMergeRepeats
 						break;;
 					[Nn]* ) exit;;
 					* ) echo "Please answer yes or no.";;


### PR DESCRIPTION
Adding file checks for biocontainer users. When using the biocontainer, Dfam must be downloaded and configured. Other small changes are also required. Here, I have added a few lines to check if Dfam is configured correctly. If not, it will download and configure the install in the biocontainer for use.