### PR TITLE
Update earlGrey - patches for lack of novel repeats

### DIFF
--- a/earlGrey
+++ b/earlGrey
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey
+	earlGrey version 4.0.6
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name


### PR DESCRIPTION
Patches to enable Earl Grey to run if an initial RepeatMasker is run and no novel repeats are found. Previously TEstrainer would fail. 