### PR TITLE
Earl Grey v6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,21 @@ Earl Grey is a full-automated transposable element (TE) annotation pipeline, lev
 
 # Changes in Latest Release
 
-Earl Grey v5.2.0 contains very small patches to improve compatibility with publicly available genome sequencing data. In rare instances, strange characters in fasta headers were causing issues preventing the pipeline from running. These have been resolved in the preparation step. 
+*Earl Grey v6.0.0 is here!* 
 
-In addition, new _pretty_ tables are now generated in the `summaryFiles` directory and at the end of a successful run. These contain the same information as the `txt` tables, but in the familiar pipe format for readability. These can be added to markdown files if required. One is produced for the high level count as well as for the family level count. Below is an example of the table that is printed at the end of Earl Grey runs as of `v5.2.0`:
+There are some relatively large changes in this release, resulting in the jump to v6.0.0. 
+
+Importantly, Earl Grey has been updated to use *Dfam version 3.9*, with RepeatMasker 4.1.8 and famdb 2.0.1. This means that there is some extra configuration required to get the pipeline running. Upon first installation and running of Earl Grey, the pipeline will check whether RepeatMasker has been configured with the correct Dfam database partitions. If not, it will warn you, generate a script that you can modify and run to configure RepeatMasker, and provide instructions to `stdout` if you want to do this yourself.
+
+Please take care to configure Earl Grey v6 with ALL required partitions. More information on the partitioning can be found at [Dfam.org](https://dfam.org/releases/current/families/FamDB/README.txt).
+
+Earl Grey v5.1.1 will continue to work for those who are happy with Dfam v3.7, but we recommend upgrading to v6.0.0 to keep up to date with the latest improvements to the database.
+
+### Previous Changes
+
+Earl Grey v5.1.1 contains very small patches to improve compatibility with publicly available genome sequencing data. In rare instances, strange characters in fasta headers were causing issues preventing the pipeline from running. These have been resolved in the preparation step. 
+
+In addition, new _pretty_ tables are now generated in the `summaryFiles` directory and at the end of a successful run. These contain the same information as the `txt` tables, but in the familiar pipe format for readability. These can be added to markdown files if required. One is produced for the high level count as well as for the family level count. Below is an example of the table that is printed at the end of Earl Grey runs as of `v5.1.1`:
 
 ```
 |TE Classification                          | Coverage (bp)| Copy Number| % Genome Coverage| Genome Size| TE Family Count|
@@ -43,8 +55,6 @@ In addition, new _pretty_ tables are now generated in the `summaryFiles` directo
 |Unclassified                               |        155836|         905|         1.4657275|    10631990|              35|
 |Non-Repeat                                 |       9818125|          NA|        92.3451301|    10631990|              NA|
 ```
-
-### Previous Changes
 
 Earl Grey v5.1.0 contains small changes that drastically improve memory usage in the divergence calculator. We have replaced the use of EMBOSS `water` with EMBOSS `matcher`, which reduces memory consumption on large alignments whilst remaining rigorous. For more information, please see the notes section in the [EMBOSS Manual](https://www.bioinformatics.nl/cgi-bin/emboss/help/matcher). This should prevent jobs running out of memory, particularly when using queuing systems and shared resources. 
 
@@ -213,13 +223,13 @@ If you would like to try Earl Grey, or prefer to use it in a browser, you can do
 
 NOTE: This pipeline is currently running with Dfam 3.7 curated elements only. We are working on updating to Dfam 3.8 for a future release. If required, you can modify the conda installation of RepeatMasker within the conda environment (do at your own risk!)
 
-Earl Grey version 5.2.0 (latest stable release) with all required and configured dependencies is found in the `toby_baril_bio` and `biooconda` conda channels. To install, simply run the following depending on your installation:
+Earl Grey version 6.0.0 (latest stable release) with all required and configured dependencies is found in the `toby_baril_bio` and `biooconda` conda channels. To install, simply run the following depending on your installation:
 ```
 # With conda
-conda create -n earlgrey -c conda-forge -c bioconda earlgrey=5.2.0
+conda create -n earlgrey -c conda-forge -c bioconda earlgrey=6.0.0
 
 # With mamba
-mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=5.2.0
+mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=6.0.0
 ```
 
 # Recommended Installation with Conda or Mamba on ARM-based Mac Systems (M chips)
@@ -393,7 +403,7 @@ brewIntel install coreutils
 
 Change TEstrainer_for_earlGrey.sh for the macOS version:
 ```
-nano $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+nano $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 
 # delete everything in this file.
 ```
@@ -604,12 +614,12 @@ Save the file with `CTRL+X` then press `Y` when asked to overwrite the file.
 
 Make sure the updated file is executable:
 ```
-chmod a+x $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+chmod a+x $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 ```
 
 Edit the script directory path in this file by running the following:
 ```
-gsed -i "s|INSERT_FILENAME_HERE|$(which earlGrey | gsed 's:bin.*:share/earlgrey-5.2.0-0/scripts/TEstrainer/scripts/:g')|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+gsed -i "s|INSERT_FILENAME_HERE|$(which earlGrey | gsed 's:bin.*:share/earlgrey-6.0.0-0/scripts/TEstrainer/scripts/:g')|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 ```
 
 Edit famdb.py for use with our environment:
@@ -619,12 +629,12 @@ gsed -i 's/python3/python/g' $(which earlGrey | gsed 's|bin.*|share/RepeatMasker
 
 Edit LTR_FINDER_PARALLEL to be compatible with zsh
 ```
-gsed -i "s|\`timeout $timeout|\`gtimeout $timeout|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/LTR_FINDER_parallel|g')
+gsed -i "s|\`timeout $timeout|\`gtimeout $timeout|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/LTR_FINDER_parallel|g')
 ```
 
 Install LTR_Finder from source
 ```
-cd $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/bin|g')
+cd $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/bin|g')
 git clone https://github.com/xzhub/LTR_Finder
 cd ./LTR_Finder/source
 make
@@ -633,14 +643,14 @@ cp * ../../LTR_FINDER.x86_64-1.0.7/
 
 Edit rcMergeRepeatsLoose:
 ```
-gsed -i 's|sed|gsed|g' $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/rcMergeRepeatsLoose|g')
+gsed -i 's|sed|gsed|g' $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/rcMergeRepeatsLoose|g')
 var=$(which earlGrey | gsed "s/earlGrey/Rscript/g")
-gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/rcMergeRepeatsLoose|g')
+gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/scripts/rcMergeRepeatsLoose|g')
 ```
 
 Edit main earlGrey script:
 ```
-gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/earlGrey|g')
+gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-6.0.0-0/earlGrey|g')
 ```
 
 Add an important directory to PERL5LIB (for RepeatMasker)
@@ -657,7 +667,7 @@ You are ready to go! Just remember to activate the _intel_ terminal, then the co
 In this case, we need to bind a system directory to the docker container. In the line below, we are binding a directory call `host_data` that is found on our current path to `/data/` in the docker container. Please replace the file path before `:` to the directory you wish to bind to `/data/` in the container. This container must be run in interactive mode the first time you use it.
 
 ```
-docker run -it -v `pwd`/host_data/:/data/ quay.io/biocontainers/earlgrey:5.2.0--h4ac6f70_0
+docker run -it -v `pwd`/host_data/:/data/ quay.io/biocontainers/earlgrey:6.0.0--h4ac6f70_0
 ```
 
 ## If you are running the container for the first time, you need to enable Earl Grey to configure the Dfam libraries correctly in interactive mode.
@@ -669,7 +679,7 @@ earlGrey -g /data/genome.fasta -s test_genome -t 8 -o /data/
 ```
 
 ## If you need the container to run offline and/or without interactive mode
-I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, there is an image with Dfam 3.7 curated elements only, and this is version 5.2.0. You can use this image by pulling the container:
+I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, there is an image with Dfam 3.7 curated elements only, and this is version 6.0.0. You can use this image by pulling the container:
 
 ```
 # Interactive mode

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Earl Grey is a full-automated transposable element (TE) annotation pipeline, lev
 
 # Changes in Latest Release
 
-Earl Grey v5.1.1 contains very small patches to improve compatibility with publicly available genome sequencing data. In rare instances, strange characters in fasta headers were causing issues preventing the pipeline from running. These have been resolved in the preparation step. 
+Earl Grey v5.2.0 contains very small patches to improve compatibility with publicly available genome sequencing data. In rare instances, strange characters in fasta headers were causing issues preventing the pipeline from running. These have been resolved in the preparation step. 
 
-In addition, new _pretty_ tables are now generated in the `summaryFiles` directory and at the end of a successful run. These contain the same information as the `txt` tables, but in the familiar pipe format for readability. These can be added to markdown files if required. One is produced for the high level count as well as for the family level count. Below is an example of the table that is printed at the end of Earl Grey runs as of `v5.1.1`:
+In addition, new _pretty_ tables are now generated in the `summaryFiles` directory and at the end of a successful run. These contain the same information as the `txt` tables, but in the familiar pipe format for readability. These can be added to markdown files if required. One is produced for the high level count as well as for the family level count. Below is an example of the table that is printed at the end of Earl Grey runs as of `v5.2.0`:
 
 ```
 |TE Classification                          | Coverage (bp)| Copy Number| % Genome Coverage| Genome Size| TE Family Count|
@@ -213,13 +213,13 @@ If you would like to try Earl Grey, or prefer to use it in a browser, you can do
 
 NOTE: This pipeline is currently running with Dfam 3.7 curated elements only. We are working on updating to Dfam 3.8 for a future release. If required, you can modify the conda installation of RepeatMasker within the conda environment (do at your own risk!)
 
-Earl Grey version 5.1.1 (latest stable release) with all required and configured dependencies is found in the `toby_baril_bio` and `biooconda` conda channels. To install, simply run the following depending on your installation:
+Earl Grey version 5.2.0 (latest stable release) with all required and configured dependencies is found in the `toby_baril_bio` and `biooconda` conda channels. To install, simply run the following depending on your installation:
 ```
 # With conda
-conda create -n earlgrey -c conda-forge -c bioconda earlgrey=5.1.1
+conda create -n earlgrey -c conda-forge -c bioconda earlgrey=5.2.0
 
 # With mamba
-mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=5.1.1
+mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=5.2.0
 ```
 
 # Recommended Installation with Conda or Mamba on ARM-based Mac Systems (M chips)
@@ -393,7 +393,7 @@ brewIntel install coreutils
 
 Change TEstrainer_for_earlGrey.sh for the macOS version:
 ```
-nano $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+nano $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 
 # delete everything in this file.
 ```
@@ -604,12 +604,12 @@ Save the file with `CTRL+X` then press `Y` when asked to overwrite the file.
 
 Make sure the updated file is executable:
 ```
-chmod a+x $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+chmod a+x $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 ```
 
 Edit the script directory path in this file by running the following:
 ```
-gsed -i "s|INSERT_FILENAME_HERE|$(which earlGrey | gsed 's:bin.*:share/earlgrey-5.1.1-0/scripts/TEstrainer/scripts/:g')|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
+gsed -i "s|INSERT_FILENAME_HERE|$(which earlGrey | gsed 's:bin.*:share/earlgrey-5.2.0-0/scripts/TEstrainer/scripts/:g')|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/TEstrainer/TEstrainer_for_earlGrey.sh|g')
 ```
 
 Edit famdb.py for use with our environment:
@@ -619,12 +619,12 @@ gsed -i 's/python3/python/g' $(which earlGrey | gsed 's|bin.*|share/RepeatMasker
 
 Edit LTR_FINDER_PARALLEL to be compatible with zsh
 ```
-gsed -i "s|\`timeout $timeout|\`gtimeout $timeout|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/LTR_FINDER_parallel|g')
+gsed -i "s|\`timeout $timeout|\`gtimeout $timeout|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/LTR_FINDER_parallel|g')
 ```
 
 Install LTR_Finder from source
 ```
-cd $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/bin|g')
+cd $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/bin|g')
 git clone https://github.com/xzhub/LTR_Finder
 cd ./LTR_Finder/source
 make
@@ -633,14 +633,14 @@ cp * ../../LTR_FINDER.x86_64-1.0.7/
 
 Edit rcMergeRepeatsLoose:
 ```
-gsed -i 's|sed|gsed|g' $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/rcMergeRepeatsLoose|g')
+gsed -i 's|sed|gsed|g' $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/rcMergeRepeatsLoose|g')
 var=$(which earlGrey | gsed "s/earlGrey/Rscript/g")
-gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/scripts/rcMergeRepeatsLoose|g')
+gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/scripts/rcMergeRepeatsLoose|g')
 ```
 
 Edit main earlGrey script:
 ```
-gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.1.1-0/earlGrey|g')
+gsed -i "s|Rscript|${var}|g" $(which earlGrey | gsed 's|bin.*|share/earlgrey-5.2.0-0/earlGrey|g')
 ```
 
 Add an important directory to PERL5LIB (for RepeatMasker)
@@ -657,7 +657,7 @@ You are ready to go! Just remember to activate the _intel_ terminal, then the co
 In this case, we need to bind a system directory to the docker container. In the line below, we are binding a directory call `host_data` that is found on our current path to `/data/` in the docker container. Please replace the file path before `:` to the directory you wish to bind to `/data/` in the container. This container must be run in interactive mode the first time you use it.
 
 ```
-docker run -it -v `pwd`/host_data/:/data/ quay.io/biocontainers/earlgrey:5.1.1--h4ac6f70_0
+docker run -it -v `pwd`/host_data/:/data/ quay.io/biocontainers/earlgrey:5.2.0--h4ac6f70_0
 ```
 
 ## If you are running the container for the first time, you need to enable Earl Grey to configure the Dfam libraries correctly in interactive mode.
@@ -669,7 +669,7 @@ earlGrey -g /data/genome.fasta -s test_genome -t 8 -o /data/
 ```
 
 ## If you need the container to run offline and/or without interactive mode
-I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, there is an image with Dfam 3.7 curated elements only, and this is version 5.1.1. You can use this image by pulling the container:
+I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, there is an image with Dfam 3.7 curated elements only, and this is version 5.2.0. You can use this image by pulling the container:
 
 ```
 # Interactive mode

--- a/earlGrey
+++ b/earlGrey
@@ -190,9 +190,10 @@ novoMask()
 	else
 		cd ${OUTDIR}/${species}_Curated_Library/
 		cat $latestFile $RepSub > ${species}_combined_library.fasta
+		latestFile=$(realpath ${species}_combined_library.fasta)
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
 		rmthreads=$(expr $ProcNum / 4)
-		RepeatMasker -lib ${OUTDIR}/${species}_Curated_Library/${species}_combined_library.fasta -norna -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
+		RepeatMasker -lib $latestFile -norna -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	fi
 }
 

--- a/earlGrey
+++ b/earlGrey
@@ -422,7 +422,9 @@ Checks()
 
 	# Dfam 3.9 checks
 	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
-	if [ -f "${library_path}/min_init.0.h5" ] ; then
+	expected_file="${library_path}/dfam39_full.0.h5"
+	file_count=$(find "$library_path" -maxdepth 1 -type f | wc -l)
+	if [ $file_count -eq 1 ] && [ -f $expected_file ] ; then
     		echo "WARNING: Earl Grey v6.0.0 has updated to Dfam v3.9." 
     		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
     		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
@@ -452,10 +454,10 @@ Checks()
     		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
     		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "" | tee -a $(pwd)/configure_dfam39.sh
     		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
     		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
@@ -473,7 +475,9 @@ Checks()
     		echo ""
     		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
     		echo "You will not see this message again if configuration is successful"
+			echo "If you only want partition 0, you do not have to do anything except rerun your Earl Grey command"
     		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+			touch ${library_path}/.earlgrey.config.complete
     		exit 2
 	fi
 }

--- a/earlGrey
+++ b/earlGrey
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 5.1.1
+	earlGrey version 5.2.0
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name

--- a/earlGrey
+++ b/earlGrey
@@ -419,6 +419,63 @@ Checks()
 			done
 		fi
 	fi
+
+	# Dfam 3.9 checks
+	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
+	if [ -f "${library_path}/min_init.0.h5" ] ; then
+    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+    		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
+    		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
+    		echo "I have written the required commands for you to faciliate the process."
+    		echo "Please follow these carefully to ensure successful configuration of RepeatMasker with Dfam 3.9."
+    		echo "As a note, these DB paritions are BIG, so only download the ones you need for your studies (or, if you do need all of them, make sure you have the space for them)"
+    		echo "########################################################"
+    		echo "A script for modification and automation of these steps has been generated in $(pwd)/configure_dfam39.sh"
+    		echo "Please open the script in your preferred text editor (e.g. nano or vim) and change the partition numbers in [] to those that you would like to download"
+    		echo "then, make the script executable (chmod +x $(pwd)/configure_dfam39.sh) and run it: ./configure_dfam39.sh"
+    		echo "Alternatively, you can run the steps below one-by-one to achieve the same outcome:"
+    		echo "########################################################"
+    		echo ""
+    		if [ -f "$(pwd)/configure_dfam39.sh" ]; then
+        		rm $(pwd)/configure_dfam39.sh
+    		fi
+    		echo "# first, change directory to the famdb library location" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd ${library_path}/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# download the partitions you require from Dfam 3.9. In the below, change the numbers or range inside the square brackets to choose your subsets." | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# e.g. to download partitions 0 to 10: [0-10]; or to download partitions 3,5, and 7: [3,5,7]; [0-16] is ALL PARTITIONS" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "curl -o 'dfam39_full.#1.h5.gz' 'https://dfam.org/releases/current/families/FamDB/dfam39_full.[0-16].h5.gz'" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# decompress Dfam 3.9 paritions" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "gunzip *.gz" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Rerun RepeatMasker configuration" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "perl ./configure -libdir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/|g') \
+    		-trf_prgm $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin/trf|g') \
+   		-rmblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-hmmer_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-abblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-crossmatch_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-default_search_engine rmblast" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		sed -i '/^perl/  s/\s\s*/ /g' $(pwd)/configure_dfam39.sh
+    		echo "########################################################"
+    		echo ""
+    		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
+    		echo "You will not see this message again if configuration is successful"
+    		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+    		exit 2
+	fi
 }
 
 # Main #

--- a/earlGrey
+++ b/earlGrey
@@ -456,6 +456,9 @@ Checks()
     		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
     		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
     		echo "# Rerun RepeatMasker configuration" | tee -a $(pwd)/configure_dfam39.sh
     		echo "perl ./configure -libdir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/|g') \
     		-trf_prgm $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin/trf|g') \
@@ -464,9 +467,6 @@ Checks()
     		-abblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
     		-crossmatch_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
     		-default_search_engine rmblast" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
     		sed -i '/^perl/  s/\s\s*/ /g' $(pwd)/configure_dfam39.sh
     		echo "########################################################"

--- a/earlGrey
+++ b/earlGrey
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 5.2.0
+	earlGrey version 6.0.0
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name
@@ -423,7 +423,7 @@ Checks()
 	# Dfam 3.9 checks
 	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
 	if [ -f "${library_path}/min_init.0.h5" ] ; then
-    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+    		echo "WARNING: Earl Grey v6.0.0 has updated to Dfam v3.9." 
     		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
     		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
     		echo "I have written the required commands for you to faciliate the process."

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -277,6 +277,63 @@ Checks()
 			done
 		fi
 	fi
+
+	# Dfam 3.9 checks
+	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
+	if [ -f "${library_path}/min_init.0.h5" ] ; then
+    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+    		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
+    		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
+    		echo "I have written the required commands for you to faciliate the process."
+    		echo "Please follow these carefully to ensure successful configuration of RepeatMasker with Dfam 3.9."
+    		echo "As a note, these DB paritions are BIG, so only download the ones you need for your studies (or, if you do need all of them, make sure you have the space for them)"
+    		echo "########################################################"
+    		echo "A script for modification and automation of these steps has been generated in $(pwd)/configure_dfam39.sh"
+    		echo "Please open the script in your preferred text editor (e.g. nano or vim) and change the partition numbers in [] to those that you would like to download"
+    		echo "then, make the script executable (chmod +x $(pwd)/configure_dfam39.sh) and run it: ./configure_dfam39.sh"
+    		echo "Alternatively, you can run the steps below one-by-one to achieve the same outcome:"
+    		echo "########################################################"
+    		echo ""
+    		if [ -f "$(pwd)/configure_dfam39.sh" ]; then
+        		rm $(pwd)/configure_dfam39.sh
+    		fi
+    		echo "# first, change directory to the famdb library location" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd ${library_path}/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# download the partitions you require from Dfam 3.9. In the below, change the numbers or range inside the square brackets to choose your subsets." | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# e.g. to download partitions 0 to 10: [0-10]; or to download partitions 3,5, and 7: [3,5,7]; [0-16] is ALL PARTITIONS" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "curl -o 'dfam39_full.#1.h5.gz' 'https://dfam.org/releases/current/families/FamDB/dfam39_full.[0-16].h5.gz'" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# decompress Dfam 3.9 paritions" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "gunzip *.gz" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Rerun RepeatMasker configuration" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "perl ./configure -libdir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/|g') \
+    		-trf_prgm $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin/trf|g') \
+   		-rmblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-hmmer_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-abblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-crossmatch_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-default_search_engine rmblast" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		sed -i '/^perl/  s/\s\s*/ /g' $(pwd)/configure_dfam39.sh
+    		echo "########################################################"
+    		echo ""
+    		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
+    		echo "You will not see this message again if configuration is successful"
+    		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+    		exit 2
+	fi
 }
 
 # Main #

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 5.2.0 (AnnotationOnly)
+	earlGrey version 6.0.0 (AnnotationOnly)
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -80,9 +80,10 @@ novoMask()
 	else
 		cd ${OUTDIR}/${species}_Curated_Library/
 		cat $latestFile $RepSub > ${species}_combined_library.fasta
+		latestFile=$(realpath ${species}_combined_library.fasta)
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
 		rmthreads=$(expr $ProcNum / 4)
-		RepeatMasker -lib ${OUTDIR}/${species}_Curated_Library/${species}_combined_library.fasta -norna -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
+		RepeatMasker -lib $latestFile -norna -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	fi
 }
 

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 5.1.1 (AnnotationOnly)
+	earlGrey version 5.2.0 (AnnotationOnly)
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -280,8 +280,10 @@ Checks()
 
 	# Dfam 3.9 checks
 	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
-	if [ -f "${library_path}/min_init.0.h5" ] ; then
-    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+	expected_file="${library_path}/dfam39_full.0.h5"
+	file_count=$(find "$library_path" -maxdepth 1 -type f | wc -l)
+	if [ $file_count -eq 1 ] && [ -f $expected_file ] ; then
+    		echo "WARNING: Earl Grey v6.0.0 has updated to Dfam v3.9." 
     		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
     		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
     		echo "I have written the required commands for you to faciliate the process."
@@ -310,10 +312,10 @@ Checks()
     		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
     		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "" | tee -a $(pwd)/configure_dfam39.sh
     		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
     		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
@@ -331,7 +333,9 @@ Checks()
     		echo ""
     		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
     		echo "You will not see this message again if configuration is successful"
+			echo "If you only want partition 0, you do not have to do anything except rerun your Earl Grey command"
     		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+			touch ${library_path}/.earlgrey.config.complete
     		exit 2
 	fi
 }

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -269,6 +269,63 @@ Checks()
                         done
                 fi
         fi
+
+        # Dfam 3.9 checks
+	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
+	if [ -f "${library_path}/min_init.0.h5" ] ; then
+    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+    		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
+    		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
+    		echo "I have written the required commands for you to faciliate the process."
+    		echo "Please follow these carefully to ensure successful configuration of RepeatMasker with Dfam 3.9."
+    		echo "As a note, these DB paritions are BIG, so only download the ones you need for your studies (or, if you do need all of them, make sure you have the space for them)"
+    		echo "########################################################"
+    		echo "A script for modification and automation of these steps has been generated in $(pwd)/configure_dfam39.sh"
+    		echo "Please open the script in your preferred text editor (e.g. nano or vim) and change the partition numbers in [] to those that you would like to download"
+    		echo "then, make the script executable (chmod +x $(pwd)/configure_dfam39.sh) and run it: ./configure_dfam39.sh"
+    		echo "Alternatively, you can run the steps below one-by-one to achieve the same outcome:"
+    		echo "########################################################"
+    		echo ""
+    		if [ -f "$(pwd)/configure_dfam39.sh" ]; then
+        		rm $(pwd)/configure_dfam39.sh
+    		fi
+    		echo "# first, change directory to the famdb library location" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd ${library_path}/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# download the partitions you require from Dfam 3.9. In the below, change the numbers or range inside the square brackets to choose your subsets." | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# e.g. to download partitions 0 to 10: [0-10]; or to download partitions 3,5, and 7: [3,5,7]; [0-16] is ALL PARTITIONS" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "curl -o 'dfam39_full.#1.h5.gz' 'https://dfam.org/releases/current/families/FamDB/dfam39_full.[0-16].h5.gz'" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# decompress Dfam 3.9 paritions" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "gunzip *.gz" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "# Rerun RepeatMasker configuration" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "perl ./configure -libdir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/|g') \
+    		-trf_prgm $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin/trf|g') \
+   		-rmblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-hmmer_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-abblast_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-crossmatch_dir $(which RepeatMasker | sed 's|/bin/RepeatMasker|/bin|g') \
+    		-default_search_engine rmblast" | tee -a $(pwd)/configure_dfam39.sh
+    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		sed -i '/^perl/  s/\s\s*/ /g' $(pwd)/configure_dfam39.sh
+    		echo "########################################################"
+    		echo ""
+    		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
+    		echo "You will not see this message again if configuration is successful"
+    		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+    		exit 2
+	fi
 }
 
 # Main #

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -3,7 +3,7 @@
 usage()
 {
         echo "  #############################
-        earlGrey version 5.1.1 (Library Construction Only)
+        earlGrey version 5.2.0 (Library Construction Only)
         Required Parameters:
                 -g == genome.fasta
                 -s == species name

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -270,10 +270,12 @@ Checks()
                 fi
         fi
 
-        # Dfam 3.9 checks
+	# Dfam 3.9 checks
 	library_path=$(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/Libraries/famdb|g')
-	if [ -f "${library_path}/min_init.0.h5" ] ; then
-    		echo "WARNING: Earl Grey v5.2.0 has updated to Dfam v3.9." 
+	expected_file="${library_path}/dfam39_full.0.h5"
+	file_count=$(find "$library_path" -maxdepth 1 -type f | wc -l)
+	if [ $file_count -eq 1 ] && [ -f $expected_file ] ; then
+    		echo "WARNING: Earl Grey v6.0.0 has updated to Dfam v3.9." 
     		echo "Before using Earl Grey, you MUST download the required partitions from Dfam (https://dfam.org/releases/current/families/FamDB/)"
     		echo "These must be located at ${library_path}/. Then, you must reconfigure RepeatMasker before using Earl Grey."
     		echo "I have written the required commands for you to faciliate the process."
@@ -302,10 +304,10 @@ Checks()
     		echo "# move up to RepeatMasker main directory" | tee -a $(pwd)/configure_dfam39.sh
     		echo "cd $(which RepeatMasker | sed 's|/bin/RepeatMasker|/share/RepeatMasker/|g')" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
-    		echo "" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "# Replace famdb with version 2.0.1 (required for the Dfam 3.9)" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "wget https://github.com/Dfam-consortium/FamDB/archive/refs/tags/2.0.1.tar.gz && tar --wildcards -zxvf 2.0.1.tar.gz FamDB-2.0.1/famdb.py FamDB-2.0.1/famdb_*.py" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "mv FamDB-2.0.1/*.py . && rm -rf 2.0.1.tar.gz FamDB-2.0.1/" | tee -a $(pwd)/configure_dfam39.sh
+    		#echo "" | tee -a $(pwd)/configure_dfam39.sh
     		echo "# save the min_init partition as a backup, just in case!" | tee -a $(pwd)/configure_dfam39.sh
     		echo "mv ${library_path}/min_init.0.h5 ${library_path}/min_init.0.h5.bak" | tee -a $(pwd)/configure_dfam39.sh
     		echo "" | tee -a $(pwd)/configure_dfam39.sh
@@ -323,7 +325,9 @@ Checks()
     		echo ""
     		echo "Following these steps should enable you to use Dfam 3.9 with RepeatMasker and Earl Grey"
     		echo "You will not see this message again if configuration is successful"
+			echo "If you only want partition 0, you do not have to do anything except rerun your Earl Grey command"
     		echo "If you are still having trouble, please open an issue on the Earl Grey github and we will try to help!"
+			touch ${library_path}/.earlgrey.config.complete
     		exit 2
 	fi
 }

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -3,7 +3,7 @@
 usage()
 {
         echo "  #############################
-        earlGrey version 5.2.0 (Library Construction Only)
+        earlGrey version 6.0.0 (Library Construction Only)
         Required Parameters:
                 -g == genome.fasta
                 -s == species name


### PR DESCRIPTION
Changes to support Dfam 3.9, in conjunction with RepeatMasker 4.1.8. This version creates a script to help users source the right partitions of Dfam for their needs. It might be a little more painful than working out of the box, but I have tried to make this as painless as possible for most users. On first run, Earl Grey will warn users that they need to choose Dfam 3.9 partitions, and will guide them through the download and configuration stages. 

This is a balance between user-friendliness and keeping up to date with the latest in rapidly-expanding databases. Happy Annotation!