### PR TITLE
Bump version to 7.2.3 and update documentation for changes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ message: >-
   If you use this software, please cite it using the
   metadata from this file.
 type: software
-version: "7.2.0"
+version: "7.2.3"
 authors:
   - given-names: Tobias
     family-names: Baril

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -6,7 +6,7 @@ I try to keep an up-to-date container in docker hub, but this might not always b
 
 ```
 # Interactive mode
-# Version 7.2.2 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
+# Version 7.2.3 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
 docker run -it -v 'pwd':/data/ tobybaril/earlgrey:latest-nodfam
 # change to library directory
 cd /data/

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'
 ```
 
 # Changes in Latest Release
-Earl Grey v7.2.2 fixes three bugs reported by users:
+Earl Grey v7.2.3 fixes three bugs reported by users:
 
 - **Off-by-one chunking in divergence_calc.py** ([#290](https://github.com/TobyBaril/EarlGrey/issues/290)): The previous floor-division chunking could produce one extra chunk when the row count was not evenly divisible by the thread count, causing the final chunk to run serially after all parallel workers had finished (effectively doubling wall-clock time in the worst case). Chunking now uses `np.array_split`, which always produces exactly `num_processes` chunks and distributes any remainder one row at a time.
 - **OSError: AF_UNIX path too long in divergence_calc.py** ([#294](https://github.com/TobyBaril/EarlGrey/issues/294)): `pybedtools.set_tempdir()` sets Python's `tempfile.tempdir` globally. The `forkserver` start method creates its Unix domain socket under `tempfile.tempdir`, so deeply-nested output paths could exceed the 108-character AF_UNIX socket limit. The divergence calculator is now passed a short per-species path in `/tmp` via `-tmp`, keeping the socket path well within the limit regardless of output directory depth.
@@ -374,13 +374,13 @@ If you would like to try Earl Grey, or prefer to use it in a browser, you can do
 
 Earl Grey version 6 uses Dfam 3.9. After installation, you MUST configure Dfam partitions as needed. Earl Grey will generate the script to do this and provide guidance when you run it for the first time. You need to specify which partitions of Dfam and/or RepBase to configure Earl Grey with. Choose partitions carefully as the combination will highly influence your results, especially if you want to pre-mask your input genome.
 
-Earl Grey version 7.2.2 (latest stable release) with all required and configured dependencies is found in the `biooconda` conda channel. To install, simply run the following depending on your installation:
+Earl Grey version 7.2.3 (latest stable release) with all required and configured dependencies is found in the `biooconda` conda channel. To install, simply run the following depending on your installation:
 ```
 # With conda
-conda create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.2
+conda create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.3
 
 # With mamba
-mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.2
+mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.3
 
 # Then run
 earlGrey
@@ -417,11 +417,11 @@ After this, you are ready to go! Just remember to activate the _intel_ terminal 
 
 A Docker container has been generated with none of Dfam 3.9, but with script generation to source required partitions
 
-I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, the recommended image ready for use is `-nodfam` version. Upon running the container interactively and running the command `earlGrey`, instructions will print to `stdout` and a script that you can use will be placed in your current working directory. After an initial setup and configuration in an interative version of the container, you can commit the changes (i.e. the Dfam configuration) using `docker commit [container_ID] yourdockerusername/earlgrey:version7.2.2-configured`. Then, you can run this container interactively, or non-interatively, to annotate focal genomes.
+I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, the recommended image ready for use is `-nodfam` version. Upon running the container interactively and running the command `earlGrey`, instructions will print to `stdout` and a script that you can use will be placed in your current working directory. After an initial setup and configuration in an interative version of the container, you can commit the changes (i.e. the Dfam configuration) using `docker commit [container_ID] yourdockerusername/earlgrey:version7.2.3-configured`. Then, you can run this container interactively, or non-interatively, to annotate focal genomes.
 
 ```
 # Interactive mode
-# Version 7.2.2 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
+# Version 7.2.3 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
 docker run -it -v 'pwd':/data/ tobybaril/earlgrey:latest-nodfam
 # change to library directory
 cd /data/
@@ -448,12 +448,12 @@ cd /data/
 docker ps -a
 
 # commit the modified container so you can use at will (replace yourdockerusername with your docker username)
-docker commit [container_ID] yourdockerusername/earlgrey:version7.2.2-configured
+docker commit [container_ID] yourdockerusername/earlgrey:version7.2.3-configured
 
 # you can then run non-interatively if required:
-docker run -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.2-configured earlGrey -g /data/GENOME.fasta -s nonInteractiveTest -o /data/ -t 8
+docker run -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.3-configured earlGrey -g /data/GENOME.fasta -s nonInteractiveTest -o /data/ -t 8
 
 # alternatively you can still run interactive sessions
-docker run -it -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.2-configured
+docker run -it -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.3-configured
 ``` 
 

--- a/conda/developmentNotes.md
+++ b/conda/developmentNotes.md
@@ -431,3 +431,157 @@ earlGrey -g test.fasta -s mem_regression_test -o . -t 16
 **Observed:** Run completed without error (exit code 0). All memory-reduction changes are confirmed compatible with a full end-to-end EarlGrey pipeline run.
 
 This also passed successfully, confirming that Earl Grey is now compatible with Python 3.10 and does not have a dependency on Python 3.9. I will now update the documentation to reflect these changes and ensure that users are aware of the new dependencies when installing Earl Grey.
+
+---
+
+# Version 7.2.3 — bug fixes, robustness improvements, and `-q` quiet-bar flag
+
+## Background
+
+Several bugs were found and fixed after the v7.2.0 memory-refinement release. The changes also add a new `-q` flag to `earlGrey` to suppress the GNU parallel progress bar, which is useful when running jobs through batch schedulers (SLURM `sbatch`, PBS, etc.) where the ANSI escape codes written by `--bar` corrupt log files.
+
+## Changes made
+
+### `conda/meta.yaml`
+
+- Bumped version to `7.2.3`.
+- Added `numpy` to the `run` dependencies. `divergence_calc.py` now imports `numpy` directly (for `np.array_split`), so it must be declared explicitly.
+- Changed `source` from a remote tarball + SHA256 to `path: ..` to allow local conda builds during development without needing a published release tarball.
+
+### `earlGrey` (main pipeline script)
+
+**1. New `-q` flag to suppress the TEstrainer parallel progress bar**
+
+```bash
+earlGrey -g genome.fa -s myspecies -o outdir -t 16 -q yes
+```
+
+When `-q yes` is passed, `earlGrey` appends `-q` to the `TEstrainer_for_earlGrey.sh` invocation. This propagates to every GNU `parallel --bar` call inside TEstrainer, replacing `--bar` with nothing so the progress bar is omitted. Useful for `sbatch` jobs where `--bar` writes ANSI codes into log files.
+
+**2. Fixed `AF_UNIX` socket path-too-long crash in `divergence_calc.py`**
+
+`pybedtools.set_tempdir()` sets `tempfile.tempdir` globally, which is also used by `forkserver` as the base directory for its `AF_UNIX` socket. If the EarlGrey output path is deeply nested, the socket path can exceed the 108-character kernel limit, causing an `OSError: AF_UNIX path too long`. The fix creates a short per-run temp directory under `/tmp`:
+
+```bash
+divcalc_tmp="/tmp/egdiv_${species}"
+mkdir -p "${divcalc_tmp}"
+python .../divergence_calc.py ... -tmp "${divcalc_tmp}"
+# ...
+rm -rf "${divcalc_tmp}"
+```
+
+### `scripts/TEstrainer/TEstrainer_for_earlGrey.sh`
+
+Added a `-q` flag that sets `BAR_FLAG=""` (default `BAR_FLAG="--bar"`). The variable is substituted into every `parallel` call so a single flag controls all progress bars in the script.
+
+### `scripts/divergenceCalc/divergence_calc.py`
+
+**1. Added `import numpy as np`** — used for `np.array_split` (see below).
+
+**2. Replaced manual chunk splitting with `np.array_split`**
+
+The old code computed `chunk_size = int(rows / num_processes)` and stepped through the DataFrame with a fixed stride. For inputs where `rows` is not evenly divisible by `num_processes` this could silently drop up to `num_processes - 1` rows. `np.array_split` distributes any remainder evenly:
+
+```python
+chunks = [in_gff.iloc[idx] for idx in np.array_split(range(len(in_gff)), num_processes)]
+```
+
+**3. Replaced all path string concatenation with `os.path.join`**
+
+All occurrences of `temp_dir + "/subdir/" + name` have been replaced with `os.path.join(temp_dir, "subdir", name)`. This fixes `OSError`s that occurred when `args.temp_dir` was passed with a trailing slash (e.g. `/tmp/egdiv_myspecies/`), which caused double-slash paths like `//pybedtools` that could fail on some systems.
+
+### `scripts/filteringOverlappingRepeats.R`
+
+Fixed a crash that occurred when no nested TEs were found in the genome. The previous code unconditionally called `mutate()` and `bind_rows()` on `nested_only`, which threw an error when `nested_only` was an empty data frame. The fix wraps the nested-TE processing in an `if (nrow(nested_only) > 0)` guard and falls through to writing `unnested_only` directly when there are no nested elements:
+
+```r
+if (nrow(nested_only) > 0) {
+  nested_only <- nested_only %>%
+    mutate(attributes = paste0(attributes, ";nested=", nested, "-round", nesting_round)) %>%
+    select(-c(nested, nesting_round))
+  output.gff <- bind_rows(nested_only, unnested_only) %>% arrange(seqid, start)
+} else {
+  output.gff <- unnested_only %>% arrange(seqid, start)
+}
+```
+
+### `scripts/divergenceCalc/divergence_plot.R`
+
+Fixed crashes in the per-superfamily Kimura divergence plots when a TE class (DNA, LINE, LTR, SINE, PLE, RC) is absent from the genome. The previous code built each plot unconditionally and then caught errors with `try(ggplot_build(...))`. The new approach checks `!is.null(...)  && nrow(...) > 0` before constructing the ggplot object:
+
+```r
+if (!is.null(divergence_eg_tes_rounded_for_superfamily_plot[["DNA"]]) &&
+    nrow(divergence_eg_tes_rounded_for_superfamily_plot[["DNA"]]) > 0) {
+  kimura_superfamily_plot_1 <- ggplot(...) + ...
+} else {
+  kimura_superfamily_plot_1 <- NULL
+}
+```
+
+The axis-flipping logic was also updated to skip `NULL` plots rather than attempting to add `scale_x_continuous()` to them (which would previously crash).
+
+## Build and test environment
+
+Build the conda package from the local source tree:
+
+```bash
+cd /data/toby/EarlGrey/conda
+conda build .
+```
+
+Create a fresh environment and install:
+
+```bash
+conda create -n earlgrey_723_test -c conda-forge -c bioconda earlgrey --use-local
+conda activate earlgrey_723_test
+```
+
+Link the Dfam libraries and configure RepeatMasker:
+
+```bash
+ln -sf /data/toby/tools/earlgrey_databases/Libraries/famdb/* \
+    /data/toby/miniforge3/envs/earlgrey_723_test/share/RepeatMasker/Libraries/famdb/
+
+cd /data/toby/miniforge3/envs/earlgrey_723_test/share/RepeatMasker
+perl configure
+```
+
+### Static checks
+
+```bash
+cd /data/toby/EarlGrey
+
+# 1. Confirm numpy is in meta.yaml
+grep 'numpy' conda/meta.yaml
+
+# 2. Confirm -q flag is wired up in earlGrey
+grep -n 'quietBar\|BAR_FLAG\|\-q' earlGrey | head -20
+
+# 3. Confirm BAR_FLAG is used in TEstrainer_for_earlGrey.sh
+grep -n 'BAR_FLAG\|bar' scripts/TEstrainer/TEstrainer_for_earlGrey.sh | grep -v '#'
+
+# 4. Confirm os.path.join used throughout divergence_calc.py (no string concat with temp_dir)
+grep 'temp_dir *+' scripts/divergenceCalc/divergence_calc.py  # should return nothing
+
+# 5. Confirm np.array_split is used for chunking
+grep 'array_split' scripts/divergenceCalc/divergence_calc.py
+
+# 6. Confirm nrow guard in filteringOverlappingRepeats.R
+grep -n 'nrow(nested_only)' scripts/filteringOverlappingRepeats.R
+```
+
+### Functional tests
+
+```bash
+cd /data/toby/testDIR/
+
+# Basic run — confirm pipeline completes with -q yes
+earlGrey -g test.fasta -s test_723_quiet -o . -t 16 -q yes
+
+# Confirm no ANSI bar codes in the log (stdout should have no ESC sequences)
+earlGrey -g test.fasta -s test_723_quiet2 -o . -t 16 -q yes 2>&1 | cat | grep -c $'\033' || echo "No ANSI codes — good"
+
+# Confirm pipeline still works without -q (bar shown as before)
+earlGrey -g test.fasta -s test_723_noq -o . -t 16
+```
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "EarlGrey" %}
-{% set version = "7.2.2" %}
+{% set version = "7.2.3" %}
 
 package:
   name: {{ name|lower }}
@@ -30,7 +30,7 @@ requirements:
     - pyfaidx
     - pyranges
     - parallel
-    - repeatmasker =4.2.2
+    - repeatmasker >=4.2.3
     - ltr_retriever
     - mafft
     - mreps

--- a/earlGrey
+++ b/earlGrey
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 7.2.2
+	earlGrey version 7.2.3
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -3,7 +3,7 @@
 usage()
 {
 	echo "	#############################
-	earlGrey version 7.2.2 (AnnotationOnly)
+	earlGrey version 7.2.3 (AnnotationOnly)
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -3,7 +3,7 @@
 usage()
 {
         echo "  #############################
-        earlGrey version 7.2.2 (Library Construction Only)
+        earlGrey version 7.2.3 (Library Construction Only)
         Required Parameters:
                 -g == genome.fasta
                 -s == species name


### PR DESCRIPTION
This pull request updates Earl Grey to version 7.2.3 and includes several important bug fixes, robustness improvements, and a new feature for improved usability in batch environments. The documentation, conda recipe, and example commands have been updated to reflect the new version. The most significant changes are summarized below.

**New features and usability improvements:**

* Added a `-q` flag to the `earlGrey` pipeline script and `TEstrainer_for_earlGrey.sh` to suppress the GNU parallel progress bar, preventing ANSI escape codes from corrupting log files in batch scheduler environments (e.g., SLURM, PBS).

**Bug fixes and robustness improvements:**

* Fixed an `OSError: AF_UNIX path too long` crash in `divergence_calc.py` by ensuring temporary directories for sockets are created in `/tmp` with short paths.
* Replaced manual chunk splitting in `divergence_calc.py` with `np.array_split` to ensure all rows are processed and distributed evenly, preventing dropped or duplicated chunks. Also switched all temp directory path concatenation to `os.path.join` for cross-platform safety.
* Fixed a crash in `filteringOverlappingRepeats.R` when no nested TEs are present by guarding nested-TE processing with an `if (nrow(nested_only) > 0)` check.
* Fixed divergence plot crashes in `divergence_plot.R` when certain TE classes are absent, by checking for null or empty data before plotting.

**Dependency and packaging updates:**

* Updated version numbers to 7.2.3 throughout documentation, conda recipe, and example commands. [[1]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L10-R10) [[2]](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cL2-R2) [[3]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L6-R6) [[4]](diffhunk://#diff-5b04d5cddcc87668e2a8cf00f48b2e0f4ec0d3982f793e101ebb4fe522590b8bL6-R6) [[5]](diffhunk://#diff-4898c41cd5f0b838aa31823b04afc0a25a32aec9937bc98b28f037032834d3d9L6-R6) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L377-R383) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L420-R424) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L451-R457) [[9]](diffhunk://#diff-2b56a3f9807ba5bfe6366a88f86c1d9c2f6f36d3e05bdd93451f48dbf6de051eL9-R9)
* Added `numpy` as a required dependency in `conda/meta.yaml` and updated `repeatmasker` to version `>=4.2.3`. [[1]](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cL33-R33) [[2]](diffhunk://#diff-91c930aba9e84e9c0f2785334367592cfe0e5ea47aee018f25d11eab4a267120R434-R587)

These changes improve the reliability, usability, and maintainability of the Earl Grey pipeline, especially for users running large-scale or automated analyses.