### PR TITLE
Bump version to 7.2.4 and enhance pipeline error handling

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ message: >-
   If you use this software, please cite it using the
   metadata from this file.
 type: software
-version: "7.2.3"
+version: "7.2.4"
 authors:
   - given-names: Tobias
     family-names: Baril

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -6,7 +6,7 @@ I try to keep an up-to-date container in docker hub, but this might not always b
 
 ```
 # Interactive mode
-# Version 7.2.3 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
+# Version 7.2.4 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
 docker run -it -v 'pwd':/data/ tobybaril/earlgrey:latest-nodfam
 # change to library directory
 cd /data/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'
 ```
 
 # Changes in Latest Release
+Earl Grey v7.2.4 improves pipeline robustness and RepeatModeler handling for small or fragmented genomes:
+
+- **Proactive RepeatModeler sampling cap** (`earlGrey`, `earlGreyLibConstruct`): the `deNovo1` function previously used a nested retry loop that ran RepeatModeler up to three times, falling back to progressively smaller `-genomeSampleSizeMax` values after each failure. It is now replaced by a single proactive run. The samplable genome size (sum of contigs ≥ 40 kb, the threshold below which RepeatModeler discards contigs) is computed upfront using `awk`, and the appropriate `-genomeSampleSizeMax` cap is derived from the cumulative RECON round thresholds (none for ≥ 363 Mb; 81 Mb for ≥ 120 Mb; 27 Mb for ≥ 39 Mb; 9 Mb for ≥ 12 Mb; 3 Mb for < 12 Mb). RepeatModeler runs exactly once with the correct flag, eliminating wasted compute on small or fragmented genomes.
+- **`set -eo pipefail`** added to `earlGrey`, `earlGreyLibConstruct`, and `earlGreyAnnotationOnly`: any command that fails mid-pipeline now immediately aborts execution, preventing downstream stages from running with missing or corrupt intermediate files.
+- **`expr` replaced with `$(( ))`** throughout all three scripts: `expr N / 4` returns exit code 1 when the result is 0 (i.e. fewer than 4 threads requested), which would abort the pipeline under `set -e` before any tool was invoked. All thread-division expressions now use bash arithmetic `$(( ProcNum / 4 ))`.
+- **`ls | head -n 1` pipelines guarded with `|| true`**: under `pipefail`, `ls` receives SIGPIPE (exit 141) when `head` exits after reading one line. All affected pipelines now append `|| true` to suppress this expected signal.
+
+### Previous Changes
 Earl Grey v7.2.3 fixes five bugs reported by users:
 
 
@@ -375,13 +383,13 @@ If you would like to try Earl Grey, or prefer to use it in a browser, you can do
 
 Earl Grey version 6 uses Dfam 3.9. After installation, you MUST configure Dfam partitions as needed. Earl Grey will generate the script to do this and provide guidance when you run it for the first time. You need to specify which partitions of Dfam and/or RepBase to configure Earl Grey with. Choose partitions carefully as the combination will highly influence your results, especially if you want to pre-mask your input genome.
 
-Earl Grey version 7.2.3 (latest stable release) with all required and configured dependencies is found in the `biooconda` conda channel. To install, simply run the following depending on your installation:
+Earl Grey version 7.2.4 (latest stable release) with all required and configured dependencies is found in the `biooconda` conda channel. To install, simply run the following depending on your installation:
 ```
 # With conda
-conda create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.3
+conda create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.4
 
 # With mamba
-mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.3
+mamba create -n earlgrey -c conda-forge -c bioconda earlgrey=7.2.4
 
 # Then run
 earlGrey
@@ -418,11 +426,11 @@ After this, you are ready to go! Just remember to activate the _intel_ terminal 
 
 A Docker container has been generated with none of Dfam 3.9, but with script generation to source required partitions
 
-I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, the recommended image ready for use is `-nodfam` version. Upon running the container interactively and running the command `earlGrey`, instructions will print to `stdout` and a script that you can use will be placed in your current working directory. After an initial setup and configuration in an interative version of the container, you can commit the changes (i.e. the Dfam configuration) using `docker commit [container_ID] yourdockerusername/earlgrey:version7.2.3-configured`. Then, you can run this container interactively, or non-interatively, to annotate focal genomes.
+I try to keep an up-to-date container in docker hub, but this might not always be the case depending on if I have had time to build and upload a new image. Currently, the recommended image ready for use is `-nodfam` version. Upon running the container interactively and running the command `earlGrey`, instructions will print to `stdout` and a script that you can use will be placed in your current working directory. After an initial setup and configuration in an interative version of the container, you can commit the changes (i.e. the Dfam configuration) using `docker commit [container_ID] yourdockerusername/earlgrey:version7.2.4-configured`. Then, you can run this container interactively, or non-interatively, to annotate focal genomes.
 
 ```
 # Interactive mode
-# Version 7.2.3 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
+# Version 7.2.4 with no preconfigured partitions (RECOMMENDED!) - bind a directory, in my case the current directory using pwd
 docker run -it -v 'pwd':/data/ tobybaril/earlgrey:latest-nodfam
 # change to library directory
 cd /data/
@@ -449,12 +457,12 @@ cd /data/
 docker ps -a
 
 # commit the modified container so you can use at will (replace yourdockerusername with your docker username)
-docker commit [container_ID] yourdockerusername/earlgrey:version7.2.3-configured
+docker commit [container_ID] yourdockerusername/earlgrey:version7.2.4-configured
 
 # you can then run non-interatively if required:
-docker run -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.3-configured earlGrey -g /data/GENOME.fasta -s nonInteractiveTest -o /data/ -t 8
+docker run -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.4-configured earlGrey -g /data/GENOME.fasta -s nonInteractiveTest -o /data/ -t 8
 
 # alternatively you can still run interactive sessions
-docker run -it -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.3-configured
+docker run -it -v 'pwd':/data/ yourdockerusername/earlgrey:version7.2.4-configured
 ``` 
 

--- a/conda/developmentNotes.md
+++ b/conda/developmentNotes.md
@@ -585,3 +585,107 @@ earlGrey -g test.fasta -s test_723_quiet2 -o . -t 16 -q yes 2>&1 | cat | grep -c
 earlGrey -g test.fasta -s test_723_noq -o . -t 16
 ```
 
+---
+
+# Version 7.2.4 — pipeline error handling, samplable genome size for RepeatModeler, and bash safety
+
+## Background
+
+Two complementary robustness improvements were identified and implemented across the three main Earl Grey pipeline scripts (`earlGrey`, `earlGreyLibConstruct`, `earlGreyAnnotationOnly`):
+
+1. The `deNovo1()` function in `earlGrey` and `earlGreyLibConstruct` used a deeply nested retry loop to work around RepeatModeler failures on small or fragmented genomes. This approach was reactive: RepeatModeler would run, fail, be retried with a smaller `-genomeSampleSizeMax`, fail again, and be retried once more — wasting potentially hours of compute and producing confusing log output. The ParTEA (pangenome) version of Earl Grey had already solved this more elegantly by pre-computing the samplable genome size and choosing the correct flag upfront.
+
+2. All three scripts lacked `set -eo pipefail`, meaning that any command that exited non-zero in the middle of a function body (outside an explicit `if` check) would silently be ignored and execution would continue into the next stage with corrupt or missing intermediate files. Additionally, two common shell idioms in the scripts would produce false failures under strict error handling: `expr N / 4` (returns exit code 1 when the result is 0) and `ls ... | head -n 1` pipelines (SIGPIPE exit 141 from `ls` when `head` exits early under `pipefail`).
+
+## Changes made
+
+### `earlGrey` and `earlGreyLibConstruct` — `deNovo1()` redesign
+
+The previous implementation:
+
+```bash
+deNovo1() {
+    RepeatModeler -threads ${ProcNum} -database ...
+    if [ ! -e ...-families.fa ]; then
+        echo "ERROR: Retrying with limit set as Round 5"
+        RepeatModeler ... -genomeSampleSizeMax 81000000
+        if [ ! -e ...-families.fa ]; then
+            echo "ERROR: Retrying with limit set as Round 4"
+            RepeatModeler ... -genomeSampleSizeMax 27000000
+            if [ ! -e ...-families.fa ]; then
+                echo "ERROR: RepeatModeler Failed" && exit 2
+            fi
+        fi
+    fi
+}
+```
+
+This ran RepeatModeler up to three times, each time with a smaller sampling cap, without any principled basis for which cap to choose. It also only covered two fallback tiers (rounds 5 and 4), leaving genomes smaller than 12 Mb (rounds 1–2) unhandled.
+
+The new implementation mirrors the approach used in ParTEA. Before invoking RepeatModeler, the samplable genome size is computed as the sum of all contigs ≥ 40 kb (the threshold below which RepeatModeler discards contigs during sampling). The appropriate `-genomeSampleSizeMax` cap is then derived from the cumulative RECON round thresholds and set in `SAMPLE_FLAG`. RepeatModeler is invoked exactly once with the correct flag, and a single post-run existence check is retained as a safety net.
+
+**Cumulative RECON round thresholds:**
+
+| Rounds supported | Cumulative threshold | Cap applied |
+|-----------------|---------------------|-------------|
+| All 6 rounds | ≥ 363 Mb (3+9+27+81+243) | none (default) |
+| Rounds 1–5 | ≥ 120 Mb (3+9+27+81) | `-genomeSampleSizeMax 81000000` |
+| Rounds 1–4 | ≥ 39 Mb (3+9+27) | `-genomeSampleSizeMax 27000000` |
+| Rounds 1–3 | ≥ 12 Mb (3+9) | `-genomeSampleSizeMax 9000000` |
+| Rounds 1–2 | < 12 Mb | `-genomeSampleSizeMax 3000000` |
+
+The samplable genome size is computed using `awk` directly on `$genome` (the `.prep` file, which is already available at the `deNovo1` call site):
+
+```bash
+GENOME_SIZE=$(awk '/^>/{if(len>=40000)sum+=len; len=0; next}{len+=length($0)} END{if(len>=40000)sum+=len; print sum+0}' "${genome}")
+```
+
+### `earlGrey`, `earlGreyLibConstruct`, `earlGreyAnnotationOnly` — `set -eo pipefail`
+
+`set -eo pipefail` was added immediately after `#!/bin/bash` in all three scripts.
+
+- `-e`: exits the script immediately if any simple command returns a non-zero exit code and is not part of a condition test.
+- `-o pipefail`: extends `-e` to pipelines — a pipeline fails if any stage within it returns non-zero, not just the last stage.
+
+Together these ensure that a failure in any tool invocation within a function body (RepeatMasker, BuildDatabase, TEstrainer, rcMergeRepeats, R scripts, etc.) will abort the pipeline at the point of failure rather than silently continuing to the next stage.
+
+### `earlGrey`, `earlGreyLibConstruct`, `earlGreyAnnotationOnly` — `expr` replaced with `$(( ))`
+
+All occurrences of `rmthreads=$(expr $ProcNum / 4)` and `strainthreads=$(expr $ProcNum / 4)` were replaced with the equivalent `$(( ProcNum / 4 ))`. The `expr` utility returns exit code 1 when the arithmetic result is 0, which occurs when `ProcNum < 4`. Under `set -e` this would abort the script before any tool was invoked if the user specified fewer than 4 threads.
+
+### `earlGrey`, `earlGreyLibConstruct`, `earlGreyAnnotationOnly` — `ls | head -n 1` pipeline fix
+
+All `ls -td ... | head -n 1` pipeline expressions used to retrieve the most recently created directory (TEstrainer output directories, HELIANO output directories) were appended with `|| true`:
+
+```bash
+latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1) || true)/..."
+```
+
+Under `pipefail`, when `head` exits after reading one line, `ls` receives SIGPIPE (exit code 141), causing the pipeline to return non-zero. This is expected behaviour — `ls` has more output but `head` is done — and `|| true` suppresses this signal without masking genuine `ls` errors (which would produce a different non-zero exit and an error message to stderr).
+
+## Static verification
+
+```bash
+cd /data/toby/EarlGrey
+
+# 1. Confirm set -eo pipefail is present in all three scripts
+grep -n 'set -eo pipefail' earlGrey earlGreyLibConstruct earlGreyAnnotationOnly
+
+# 2. Confirm no remaining expr calls
+grep -n 'expr' earlGrey earlGreyLibConstruct earlGreyAnnotationOnly
+
+# 3. Confirm ls|head pipelines are guarded
+grep -n 'head -n 1' earlGrey earlGreyLibConstruct earlGreyAnnotationOnly
+
+# 4. Confirm GENOME_SIZE and SAMPLE_FLAG logic is present in deNovo1
+grep -n 'GENOME_SIZE\|SAMPLE_FLAG' earlGrey earlGreyLibConstruct
+```
+
+**Expected for check 1:** Three lines, one per script, each showing `set -eo pipefail` at line 2.
+
+**Expected for check 2:** No output (all `expr` calls replaced).
+
+**Expected for check 3:** All matching lines should contain `|| true`.
+
+**Expected for check 4:** Both scripts should show `GENOME_SIZE` and `SAMPLE_FLAG` variable assignments and the five-tier `if/elif/else` block inside `deNovo1`.
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "EarlGrey" %}
-{% set version = "7.2.3" %}
+{% set version = "7.2.4" %}
 
 package:
   name: {{ name|lower }}

--- a/earlGrey
+++ b/earlGrey
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 usage()
 {
 	echo "	#############################
-	earlGrey version 7.2.3
+	earlGrey version 7.2.4
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name
@@ -106,7 +107,7 @@ getRepeatMaskerFasta()
 firstMask()
 {
 	cd ${OUTDIR}/${species}_RepeatMasker
-        rmthreads=$(expr $ProcNum / 4)
+	rmthreads=$(( ProcNum / 4 ))
 	RepeatMasker -species $RepSpec -no_is -lcambig -s -a -pa $rmthreads -dir $OUTDIR/${species}_RepeatMasker $genome
 	if [ ! -f ${OUTDIR}/${species}_RepeatMasker/*.masked ]; then
 		echo "ERROR: RepeatMasker failed, please check logs. This is likely because of an invalid species search term, if issue persists please use NCBI Taxids (E.G Drosophila is replaced with 7125)"; exit 2
@@ -118,7 +119,7 @@ firstMask()
 firstMaskCustomLib()
 {
 	cd ${OUTDIR}/${species}_RepeatMasker
-	rmthreads=$(expr $ProcNum / 4)
+	rmthreads=$(( ProcNum / 4 ))
 	RepeatMasker -lib ${startCust} -no_is -lcambig -s -a -pa $rmthreads -dir $OUTDIR/${species}_RepeatMasker $genome
 	RepSub=${startCust}
 	if [ ! -f ${OUTDIR}/${species}_RepeatMasker/*.masked ]; then
@@ -141,22 +142,49 @@ buildDB()
 }
 
 # Subprocess deNovo1
-# Run the initial de novo annotation run with RepeatModeler2, with error catches for weird genome sizes
+# Run the initial de novo annotation run with RepeatModeler2.
+# The genomeSampleSizeMax flag is set based on the samplable genome size (contigs >= 40 kb)
+# to avoid RepeatModeler failures on small or fragmented genomes.
 deNovo1()
 {
 	cd ${OUTDIR}/${species}_RepeatModeler
-	RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species}
+
+	# Compute samplable genome size: sum of contigs >= 40 kb only.
+	# RepeatModeler discards contigs shorter than 40 kb during sampling, so using
+	# the total genome size would overestimate the sequence available per round.
+	GENOME_SIZE=$(awk '/^>/{if(len>=40000)sum+=len; len=0; next}{len+=length($0)} END{if(len>=40000)sum+=len; print sum+0}' "${genome}")
+	echo "Samplable genome size (contigs >= 40 kb): ${GENOME_SIZE} bp"
+
+	# Set -genomeSampleSizeMax to the highest RECON round threshold the genome
+	# can support. Thresholds are cumulative across rounds (r2=3M, r3=9M, r4=27M,
+	# r5=81M, r6=243M), so the samplable size must cover all rounds up to the cap:
+	#   >= 363M (3+9+27+81+243): no cap  -> all 6 rounds
+	#   >= 120M (3+9+27+81):     cap 81M  -> rounds 1-5
+	#   >=  39M (3+9+27):        cap 27M  -> rounds 1-4
+	#   >=  12M (3+9):           cap  9M  -> rounds 1-3
+	#   <   12M:                 cap  3M  -> rounds 1-2
+	SAMPLE_FLAG=""
+	if [ "${GENOME_SIZE}" -ge 363000000 ] 2>/dev/null; then
+		: # genome large enough for all rounds; use RepeatModeler default
+	elif [ "${GENOME_SIZE}" -ge 120000000 ] 2>/dev/null; then
+		echo "Capping at round 5 (-genomeSampleSizeMax 81000000)"
+		SAMPLE_FLAG="-genomeSampleSizeMax 81000000"
+	elif [ "${GENOME_SIZE}" -ge 39000000 ] 2>/dev/null; then
+		echo "Capping at round 4 (-genomeSampleSizeMax 27000000)"
+		SAMPLE_FLAG="-genomeSampleSizeMax 27000000"
+	elif [ "${GENOME_SIZE}" -ge 12000000 ] 2>/dev/null; then
+		echo "Capping at round 3 (-genomeSampleSizeMax 9000000)"
+		SAMPLE_FLAG="-genomeSampleSizeMax 9000000"
+	else
+		echo "Capping at round 2 (-genomeSampleSizeMax 3000000)"
+		SAMPLE_FLAG="-genomeSampleSizeMax 3000000"
+	fi
+
+	RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} ${SAMPLE_FLAG}
+
 	if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-		echo "ERROR: RepeatModeler Failed, Retrying with limit set as Round 5"
-		RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} -genomeSampleSizeMax 81000000
-		if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-			echo "ERROR: RepeatModeler Failed, Retrying with limit set as Round 4"
-			RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} -genomeSampleSizeMax 27000000
-			if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-				echo "ERROR: RepeatModeler Failed"
-				exit 2
-			fi
-		fi
+		echo "ERROR: RepeatModeler Failed"
+		exit 2
 	fi
 }
 
@@ -166,12 +194,12 @@ strainer()
 {
 	cd ${OUTDIR}/${species}_strainer/
 	if [ "$ProcNum" -ge 4 ]; then
-		strainthreads=$(expr $ProcNum / 4)
+		strainthreads=$(( ProcNum / 4 ))
 	else
 		strainthreads=$ProcNum
 	fi
 	${SCRIPT_DIR}/TEstrainer/TEstrainer_for_earlGrey.sh -g $genome -l ${OUTDIR}/${species}_Database/${species}-families.fa -t ${strainthreads} -f $Flank -r $num -n $no_seq -m $min_seq$([ "$quietBar" == "yes" ] && echo " -q")
-	latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1))/${species}-families.fa.strained"
+	latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1) || true)/${species}-families.fa.strained"
 	cp $latestFile ${OUTDIR}/${species}_strainer/
 }
 
@@ -185,12 +213,12 @@ strainerResume() {
 		exit 2
 	fi
 	if [ "$ProcNum" -ge 4 ]; then
-		strainthreads=$(expr $ProcNum / 4)
+		strainthreads=$(( ProcNum / 4 ))
 	else
 		strainthreads=$ProcNum
 	fi
 	${SCRIPT_DIR}/TEstrainer/TEstrainer_for_earlGrey.sh -g $genome -l ${OUTDIR}/${species}_Database/${species}-families.fa -t ${strainthreads} -f $Flank -r $num -n $no_seq -m $min_seq$([ "$quietBar" == "yes" ] && echo " -q") -d ${strainDataDir} -R
-	latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1))/${species}-families.fa.strained"
+	latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1) || true)/${species}-families.fa.strained"
 	cp $latestFile ${OUTDIR}/${species}_strainer/
 }
 
@@ -210,7 +238,7 @@ novoMask()
 {
 	if [ -z "$RepSpec" ] && [ -z "$startCust" ]; then
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
-		rmthreads=$(expr $ProcNum / 4)
+		rmthreads=$(( ProcNum / 4 ))
 		RepeatMasker -lib $latestFile -no_is -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	else
 		mkdir -p $OUTDIR/${species}_Curated_Library/
@@ -218,7 +246,7 @@ novoMask()
 		cat $latestFile $RepSub > ${species}_combined_library.fasta
 		latestFile=$(realpath ${species}_combined_library.fasta)
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
-		rmthreads=$(expr $ProcNum / 4)
+		rmthreads=$(( ProcNum / 4 ))
 		RepeatMasker -lib $latestFile -no_is -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	fi
 }
@@ -639,7 +667,7 @@ if [ "$heli" == "yes" ]; then
 		heliano_optional
 	else
 		stage="HELITRON detection already complete, skipping..." && runningTea
-		helitron_gff="$(realpath $(ls -td -- ${OUTDIR}/${species}_heliano/*/ | head -n 1))/RC.representative.gff"
+		helitron_gff="$(realpath $(ls -td -- ${OUTDIR}/${species}_heliano/*/ | head -n 1) || true)/RC.representative.gff"
 		echo "HELITRON GFF: $helitron_gff"
 	fi
 	sleep 1

--- a/earlGreyAnnotationOnly
+++ b/earlGreyAnnotationOnly
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 usage()
 {
 	echo "	#############################
-	earlGrey version 7.2.3 (AnnotationOnly)
+	earlGrey version 7.2.4 (AnnotationOnly)
 	Required Parameters:
 		-g == genome.fasta
 		-s == species name
@@ -75,7 +76,7 @@ novoMask()
 {
 	if [ -z "$RepSpec" ]; then
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
-		rmthreads=$(expr $ProcNum / 4)
+		rmthreads=$(( ProcNum / 4 ))
 		RepeatMasker -lib $latestFile -no_is -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	else
 		mkdir -p $OUTDIR/${species}_Curated_Library/
@@ -83,7 +84,7 @@ novoMask()
 		cat $latestFile $RepSub > ${species}_combined_library.fasta
 		latestFile=$(realpath ${species}_combined_library.fasta)
 		cd ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/
-		rmthreads=$(expr $ProcNum / 4)
+		rmthreads=$(( ProcNum / 4 ))
 		RepeatMasker -lib $latestFile -no_is -lcambig -s -a -pa $rmthreads -dir ${OUTDIR}/${species}_RepeatMasker_Against_Custom_Library/ $genome
 	fi
 }
@@ -400,7 +401,7 @@ if [ "$heli" == "yes" ]; then
 		heliano_optional
 	else
 		stage="HELITRON detection already complete, skipping..." && runningTea
-		helitron_gff="$(realpath $(ls -td -- ${OUTDIR}/${species}_heliano/*/ | head -n 1))/RC.representative.gff"
+		helitron_gff="$(realpath $(ls -td -- ${OUTDIR}/${species}_heliano/*/ | head -n 1) || true)/RC.representative.gff"
 		echo "HELITRON GFF: $helitron_gff"
 	fi
 	sleep 1

--- a/earlGreyLibConstruct
+++ b/earlGreyLibConstruct
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 usage()
 {
         echo "  #############################
-        earlGrey version 7.2.3 (Library Construction Only)
+        earlGrey version 7.2.4 (Library Construction Only)
         Required Parameters:
                 -g == genome.fasta
                 -s == species name
@@ -95,7 +96,7 @@ getRepeatMaskerFasta()
 firstMask()
 {
         cd ${OUTDIR}/${species}_RepeatMasker
-        rmthreads=$(expr $ProcNum / 4)
+        rmthreads=$(( ProcNum / 4 ))
         RepeatMasker -species $RepSpec -no_is -lcambig -s -a -pa $rmthreads -dir $OUTDIR/${species}_RepeatMasker $genome
         if [ ! -f ${OUTDIR}/${species}_RepeatMasker/*.masked ]; then
                 echo "ERROR: RepeatMasker failed, please check logs. This is likely because of an invalid species search term, if issue persists please use NCBI Taxids (E.G Drosophila is replaced with 7125)"; exit 2
@@ -107,7 +108,7 @@ firstMask()
 firstMaskCustomLib()
 {
         cd ${OUTDIR}/${species}_RepeatMasker
-        rmthreads=$(expr $ProcNum / 4)
+        rmthreads=$(( ProcNum / 4 ))
         RepeatMasker -lib ${startCust} -no_is -lcambig -s -a -pa $rmthreads -dir $OUTDIR/${species}_RepeatMasker $genome
         RepSub=${startCust}
         if [ ! -f ${OUTDIR}/${species}_RepeatMasker/*.masked ]; then
@@ -130,22 +131,49 @@ buildDB()
 }
 
 # Subprocess deNovo1
-# Run the initial de novo annotation run with RepeatModeler2, with error catches for weird genome sizes
+# Run the initial de novo annotation run with RepeatModeler2.
+# The genomeSampleSizeMax flag is set based on the samplable genome size (contigs >= 40 kb)
+# to avoid RepeatModeler failures on small or fragmented genomes.
 deNovo1()
 {
         cd ${OUTDIR}/${species}_RepeatModeler
-        RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species}
+
+        # Compute samplable genome size: sum of contigs >= 40 kb only.
+        # RepeatModeler discards contigs shorter than 40 kb during sampling, so using
+        # the total genome size would overestimate the sequence available per round.
+        GENOME_SIZE=$(awk '/^>/{if(len>=40000)sum+=len; len=0; next}{len+=length($0)} END{if(len>=40000)sum+=len; print sum+0}' "${genome}")
+        echo "Samplable genome size (contigs >= 40 kb): ${GENOME_SIZE} bp"
+
+        # Set -genomeSampleSizeMax to the highest RECON round threshold the genome
+        # can support. Thresholds are cumulative across rounds (r2=3M, r3=9M, r4=27M,
+        # r5=81M, r6=243M), so the samplable size must cover all rounds up to the cap:
+        #   >= 363M (3+9+27+81+243): no cap  -> all 6 rounds
+        #   >= 120M (3+9+27+81):     cap 81M  -> rounds 1-5
+        #   >=  39M (3+9+27):        cap 27M  -> rounds 1-4
+        #   >=  12M (3+9):           cap  9M  -> rounds 1-3
+        #   <   12M:                 cap  3M  -> rounds 1-2
+        SAMPLE_FLAG=""
+        if [ "${GENOME_SIZE}" -ge 363000000 ] 2>/dev/null; then
+                : # genome large enough for all rounds; use RepeatModeler default
+        elif [ "${GENOME_SIZE}" -ge 120000000 ] 2>/dev/null; then
+                echo "Capping at round 5 (-genomeSampleSizeMax 81000000)"
+                SAMPLE_FLAG="-genomeSampleSizeMax 81000000"
+        elif [ "${GENOME_SIZE}" -ge 39000000 ] 2>/dev/null; then
+                echo "Capping at round 4 (-genomeSampleSizeMax 27000000)"
+                SAMPLE_FLAG="-genomeSampleSizeMax 27000000"
+        elif [ "${GENOME_SIZE}" -ge 12000000 ] 2>/dev/null; then
+                echo "Capping at round 3 (-genomeSampleSizeMax 9000000)"
+                SAMPLE_FLAG="-genomeSampleSizeMax 9000000"
+        else
+                echo "Capping at round 2 (-genomeSampleSizeMax 3000000)"
+                SAMPLE_FLAG="-genomeSampleSizeMax 3000000"
+        fi
+
+        RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} ${SAMPLE_FLAG}
+
         if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-                echo "ERROR: RepeatModeler Failed, Retrying with limit set as Round 5"
-                RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} -genomeSampleSizeMax 81000000
-                if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-                        echo "ERROR: RepeatModeler Failed, Retrying with limit set as Round 4"
-                        RepeatModeler -threads ${ProcNum} -database ${OUTDIR}/${species}_Database/${species} -genomeSampleSizeMax 27000000
-                        if [ ! -e ${OUTDIR}/${species}_Database/${species}-families.fa ]; then
-                                echo "ERROR: RepeatModeler Failed"
-                                exit 2
-                        fi
-                fi
+                echo "ERROR: RepeatModeler Failed"
+                exit 2
         fi
 }
 
@@ -155,12 +183,12 @@ strainer()
 {
         cd ${OUTDIR}/${species}_strainer/
 	if [ "$ProcNum" -ge 4 ]; then
-		strainthreads=$(expr $ProcNum / 4)
+		strainthreads=$(( ProcNum / 4 ))
 	else
 		strainthreads=$ProcNum
 	fi
         ${SCRIPT_DIR}/TEstrainer/TEstrainer_for_earlGrey.sh -g $genome -l ${OUTDIR}/${species}_Database/${species}-families.fa -t ${strainthreads} -f $Flank -r $num -n $no_seq -m $min_seq
-        latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1))/${species}-families.fa.strained"
+        latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1) || true)/${species}-families.fa.strained"
         cp $latestFile ${OUTDIR}/${species}_strainer/
 }
 
@@ -174,12 +202,12 @@ strainerResume() {
         exit 2
     fi
     if [ "$ProcNum" -ge 4 ]; then
-        strainthreads=$(expr $ProcNum / 4)
+        strainthreads=$(( ProcNum / 4 ))
     else
         strainthreads=$ProcNum
     fi
     ${SCRIPT_DIR}/TEstrainer/TEstrainer_for_earlGrey.sh -g $genome -l ${OUTDIR}/${species}_Database/${species}-families.fa -t ${strainthreads} -f $Flank -r $num -n $no_seq -m $min_seq -d ${strainDataDir} -R
-    latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1))/${species}-families.fa.strained"
+    latestFile="$(realpath $(ls -td -- ${OUTDIR}/${species}_strainer/*/ | head -n 1) || true)/${species}-families.fa.strained"
     cp $latestFile ${OUTDIR}/${species}_strainer/
 }
 


### PR DESCRIPTION
This pull request updates Earl Grey to version 7.2.4, focusing on major improvements to pipeline robustness, especially for handling small or fragmented genomes in RepeatModeler, and strengthening error handling in the main pipeline scripts. It also updates all references and documentation to reflect the new version.

**Pipeline robustness and error handling improvements:**

* `earlGrey`, `earlGreyLibConstruct`: The `deNovo1()` function now proactively computes the samplable genome size (contigs ≥ 40 kb) and sets the appropriate `-genomeSampleSizeMax` cap for RepeatModeler based on cumulative RECON round thresholds. This replaces the previous nested retry logic, making the pipeline more efficient and reliable for small or fragmented genomes.
* `earlGrey`, `earlGreyLibConstruct`, `earlGreyAnnotationOnly`: Added `set -eo pipefail` at the start of each script to ensure the pipeline aborts immediately on any command failure, preventing silent errors and downstream corruption. [[1]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883R2-R7) [[2]](diffhunk://#diff-5b04d5cddcc87668e2a8cf00f48b2e0f4ec0d3982f793e101ebb4fe522590b8bR2-R7)
* All scripts: Replaced all uses of `expr` with Bash arithmetic `$(( ))` to avoid false failures when dividing thread counts, especially when fewer than 4 threads are requested. [[1]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L109-R110) [[2]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L121-R122) [[3]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L169-R202) [[4]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L188-R221) [[5]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L213-R249)
* All scripts: Guarded all `ls | head -n 1` pipelines with `|| true` to suppress expected SIGPIPE errors under `pipefail`, ensuring robust directory/file selection. [[1]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L169-R202) [[2]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L188-R221) [[3]](diffhunk://#diff-84e76b1ed12d9e4e49df7f56ef2facbe585116c2144894e815215c7b40976883L642-R670)

**Documentation and version updates:**

* Updated all references to version 7.2.4 in `README.md`, `Docker/README.md`, `CITATION.cff`, and `conda/meta.yaml`, and added detailed release notes describing the new error handling and RepeatModeler improvements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R56) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L378-R392) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L421-R433) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L452-R466) [[5]](diffhunk://#diff-2b56a3f9807ba5bfe6366a88f86c1d9c2f6f36d3e05bdd93451f48dbf6de051eL9-R9) [[6]](diffhunk://#diff-9b9f76394a441ff40bf8d7a0f3e0ddd7ae97abfa9a9a6abaedccf76dc4d51295L10-R10) [[7]](diffhunk://#diff-e4db5852c039b631ee11f2e6f3b000f53e0774918ff1ba8f983f428f72b4fe4cL2-R2) [[8]](diffhunk://#diff-91c930aba9e84e9c0f2785334367592cfe0e5ea47aee018f25d11eab4a267120R588-R691)

These changes significantly improve the reliability and user experience of the Earl Grey pipeline, especially for users working with non-standard genome assemblies.